### PR TITLE
Google Analytics for UDF Users

### DIFF
--- a/application/docs/_templates/layout.html
+++ b/application/docs/_templates/layout.html
@@ -1,23 +1,13 @@
 {% extends "!layout.html" %}
 
-{% block footer %}
-{{ super() }}
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
-var pageTracker = _gat._getTracker("<!-- Global site tag (gtag.js) - Google Analytics -->
+ 
+
+{%- block extrahead %}
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TZT9HGJW2X"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
   gtag('config', 'G-TZT9HGJW2X');
-</script>");
-pageTracker._trackPageview();
-} catch(err) {}</script>
+</script>
 {% endblock %}
-

--- a/application/docs/_templates/layout.html
+++ b/application/docs/_templates/layout.html
@@ -3,11 +3,11 @@
  
 
 {%- block extrahead %}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-F46FHDP7PQ"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-EWD26Y1WGR"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-F46FHDP7PQ');
+  gtag('config', 'G-EWD26Y1WGR');
 </script>
 {% endblock %}

--- a/application/docs/_templates/layout.html
+++ b/application/docs/_templates/layout.html
@@ -3,11 +3,11 @@
  
 
 {%- block extrahead %}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-TZT9HGJW2X"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-F46FHDP7PQ"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-TZT9HGJW2X');
+  gtag('config', 'G-F46FHDP7PQ');
 </script>
 {% endblock %}

--- a/application/docs/_templates/layout.html
+++ b/application/docs/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+
+{% block footer %}
+{{ super() }}
+<script type="text/javascript">
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+</script>
+<script type="text/javascript">
+try {
+var pageTracker = _gat._getTracker("<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TZT9HGJW2X"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TZT9HGJW2X');
+</script>");
+pageTracker._trackPageview();
+} catch(err) {}</script>
+{% endblock %}
+


### PR DESCRIPTION
The gtab collects anonymized user data when users launch the lab through UDF. This will be used for determining which pages are taking students longer than expected and general stats -- nothing specific to the user.